### PR TITLE
improve mobile responsiveness without breaking desktop layout

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -64,7 +64,7 @@ function ExploreContent() {
       )}
 
       {loading && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 px-5 py-3 bg-slate-900/90 backdrop-blur border border-slate-800 rounded-full text-sm text-slate-300 flex items-center gap-3">
+        <div className="fixed bottom-16 md:bottom-6 left-4 right-4 md:left-1/2 md:right-auto md:-translate-x-1/2 z-40 px-4 md:px-5 py-3 bg-slate-900/90 backdrop-blur border border-slate-800 rounded-full text-sm text-slate-300 flex items-center justify-center gap-3">
           <div className="w-2 h-2 bg-sky-400 rounded-full animate-pulse"></div>
           {loadingMessage || 'Loading...'}
         </div>
@@ -72,12 +72,12 @@ function ExploreContent() {
 
       {userId && useGraphStore.getState().rootNodes.length === 0 && !loading && (
         <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-10">
-          <div className="text-center pointer-events-auto">
+          <div className="text-center pointer-events-auto px-6">
             <div className="text-slate-500 text-sm uppercase tracking-widest mb-3">
               Empty Graph
             </div>
-            <div className="text-slate-300 text-xl font-light">
-              Add a topic in the top right to begin exploring.
+            <div className="text-slate-300 text-lg md:text-xl font-light">
+              Add a topic above to begin exploring.
             </div>
           </div>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -58,3 +58,40 @@ input::placeholder {
 .node-label {
   user-select: none;
 }
+
+/* Sidebar slide-in animation */
+@keyframes slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in-right {
+  animation: slide-in-right 0.25s ease-out;
+}
+
+/* Hide scrollbar but allow scrolling */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
+/* Safe area for notched phones */
+.pb-safe {
+  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+}
+
+/* Better touch targets on mobile */
+@media (hover: none) and (pointer: coarse) {
+  button,
+  a,
+  input {
+    min-height: 44px;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,16 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 
 export const metadata: Metadata = {
   title: 'Graphmind — 3D Knowledge Explorer',
   description:
     'Explore any topic as a 3D fractal knowledge graph. Powered by Wikipedia and Claude.',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,7 +44,7 @@ export default function LandingPage() {
       />
 
       {/* Animated logo */}
-      <div className="relative w-28 h-28 mb-12">
+      <div className="relative w-20 h-20 mb-8 md:w-28 md:h-28 md:mb-12">
         <div className="logo-ring absolute inset-0 border border-slate-600/40 rounded-full" />
         <div className="logo-ring-reverse absolute inset-3 border border-slate-500/25 rounded-full" />
         <div className="absolute inset-6 border border-slate-500/15 rounded-full" />
@@ -54,8 +54,8 @@ export default function LandingPage() {
       </div>
 
       <h1
-        className="text-slate-100 text-center mb-10 select-none"
-        style={{ fontWeight: 200, fontSize: '42px', lineHeight: 1.1, letterSpacing: '-0.01em' }}
+        className="text-slate-100 text-center mb-8 md:mb-10 select-none text-[28px] md:text-[42px]"
+        style={{ fontWeight: 200, lineHeight: 1.1, letterSpacing: '-0.01em' }}
       >
         I want to learn
       </h1>
@@ -80,7 +80,7 @@ export default function LandingPage() {
             onFocus={() => setFocused(true)}
             onBlur={() => setFocused(false)}
             placeholder="Type a topic..."
-            className="w-full bg-transparent text-slate-100 text-lg py-4 px-5 pr-20 focus:outline-none placeholder-slate-500 font-light"
+            className="w-full bg-transparent text-slate-100 text-base md:text-lg py-3 md:py-4 px-4 md:px-5 pr-16 md:pr-20 focus:outline-none placeholder-slate-500 font-light"
             autoFocus
             autoComplete="off"
           />

--- a/components/Breadcrumb.tsx
+++ b/components/Breadcrumb.tsx
@@ -29,19 +29,19 @@ export default function Breadcrumb() {
   }, [path]);
 
   return (
-    <nav className="fixed top-4 left-4 z-20 flex items-center gap-2 text-sm">
+    <nav className="fixed top-4 left-3 md:left-4 z-20 flex items-center gap-1.5 md:gap-2 text-sm max-w-[70vw] md:max-w-none overflow-x-auto scrollbar-hide">
       <button
         onClick={() => goToLevel(-1)}
-        className="text-slate-400 hover:text-sky-300 transition-colors"
+        className="text-slate-400 hover:text-sky-300 transition-colors shrink-0"
       >
         Home
       </button>
       {labels.map((label, i) => (
-        <span key={i} className="flex items-center gap-2">
+        <span key={i} className="flex items-center gap-1.5 md:gap-2 shrink-0">
           <span className="text-slate-600">›</span>
           <button
             onClick={() => goToLevel(i)}
-            className={`transition-colors ${
+            className={`transition-colors truncate max-w-[120px] md:max-w-none ${
               i === labels.length - 1
                 ? 'text-emerald-400'
                 : 'text-slate-400 hover:text-sky-300'

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -23,7 +23,7 @@ export default function PromptInput() {
   return (
     <form
       onSubmit={submit}
-      className="fixed top-4 right-4 z-20 flex items-center gap-2"
+      className="fixed top-4 left-3 right-3 md:left-auto md:right-4 z-20 flex items-center gap-2"
     >
       <input
         type="text"
@@ -31,12 +31,12 @@ export default function PromptInput() {
         onChange={(e) => setValue(e.target.value)}
         placeholder="Add a topic…"
         disabled={loading}
-        className="bg-slate-900/80 backdrop-blur border border-slate-800 text-slate-200 text-sm px-3 py-2 rounded focus:outline-none focus:border-sky-500 w-56"
+        className="bg-slate-900/80 backdrop-blur border border-slate-800 text-slate-200 text-sm px-3 py-2.5 md:py-2 rounded focus:outline-none focus:border-sky-500 flex-1 md:flex-none md:w-56"
       />
       <button
         type="submit"
         disabled={loading || !value.trim()}
-        className="px-4 py-2 bg-sky-500/20 border border-sky-500/40 text-sky-300 text-sm rounded hover:bg-sky-500/30 disabled:opacity-40"
+        className="px-4 py-2.5 md:py-2 bg-sky-500/20 border border-sky-500/40 text-sky-300 text-sm rounded hover:bg-sky-500/30 disabled:opacity-40 shrink-0"
       >
         Add
       </button>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -82,13 +82,13 @@ export default function Sidebar() {
   }
 
   return (
-    <aside className="fixed top-0 right-0 h-full w-[420px] max-w-[90vw] bg-[#0b0d14]/95 backdrop-blur-md border-l border-slate-800 z-30 flex flex-col">
-      <div className="p-5 border-b border-slate-800 flex items-start justify-between">
+    <aside className="fixed top-0 right-0 h-full w-full md:w-[420px] md:max-w-[90vw] bg-[#0b0d14]/95 backdrop-blur-md border-l border-slate-800 z-30 flex flex-col animate-slide-in-right">
+      <div className="p-4 md:p-5 border-b border-slate-800 flex items-start justify-between">
         <div>
           <div className="text-xs uppercase tracking-widest text-slate-500 mb-1">
             Currently exploring
           </div>
-          <h2 className="text-emerald-400 text-2xl font-light leading-tight">
+          <h2 className="text-emerald-400 text-xl md:text-2xl font-light leading-tight">
             {currentParent.label}
           </h2>
           <div className="flex items-center gap-3 mt-1">
@@ -123,14 +123,14 @@ export default function Sidebar() {
         </div>
         <button
           onClick={() => setSidebarOpen(false)}
-          className="text-slate-500 hover:text-slate-200 text-xl leading-none"
+          className="text-slate-500 hover:text-slate-200 text-2xl md:text-xl leading-none p-1 -mr-1"
           aria-label="Close"
         >
           ×
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-5 space-y-4" ref={scrollRef}>
+      <div className="flex-1 overflow-y-auto p-4 md:p-5 space-y-4" ref={scrollRef}>
         <section>
           <RichSummary markdown={currentParent.summary ?? ''} />
         </section>
@@ -159,7 +159,7 @@ export default function Sidebar() {
         )}
       </div>
 
-      <div className="p-4 border-t border-slate-800">
+      <div className="p-3 md:p-4 border-t border-slate-800 pb-safe">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -24,28 +24,28 @@ export default function TopBar() {
   }
 
   return (
-    <div className="fixed bottom-4 left-4 z-20 flex items-center gap-3 text-xs">
-      <div className="px-3 py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-400">
+    <div className="fixed bottom-4 left-3 right-3 md:left-4 md:right-auto z-20 flex items-center gap-2 md:gap-3 text-xs flex-wrap">
+      <div className="px-3 py-2.5 md:py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-400">
         <span className="text-slate-500">Topics:</span>{' '}
         <span className="text-slate-200">{rootNodes.length}</span>
       </div>
       {path.length > 0 && (
         <button
           onClick={goBack}
-          className="px-3 py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-300 hover:text-sky-300"
+          className="px-3 py-2.5 md:py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-300 hover:text-sky-300"
         >
           ← Back
         </button>
       )}
       <button
         onClick={handleReset}
-        className="px-3 py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-400 hover:text-rose-400"
+        className="px-3 py-2.5 md:py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-400 hover:text-rose-400"
       >
         Reset
       </button>
       <button
         onClick={handleSignOut}
-        className="px-3 py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-400 hover:text-slate-200"
+        className="px-3 py-2.5 md:py-2 bg-slate-900/80 backdrop-blur border border-slate-800 rounded text-slate-400 hover:text-slate-200"
       >
         Sign out
       </button>


### PR DESCRIPTION
Add Tailwind responsive breakpoints (md:) across all UI components so
mobile gets proper sizing while desktop remains identical. Key changes:
- Landing page: scale heading/logo/input for smaller screens
- Sidebar: full-width on mobile with slide-in animation
- TopBar: wrapping buttons, larger tap targets on mobile
- PromptInput: full-width input on mobile, fixed width on desktop
- Breadcrumb: overflow scroll + truncation on mobile
- Loading/empty states: responsive positioning and text
- Global CSS: slide animation, scrollbar-hide, safe-area padding,
  44px min touch targets on touch devices
- Layout: viewport-fit=cover for notched phones

https://claude.ai/code/session_01RCQJHrBYNqz2judGHQETNn