### PR TITLE
don't auto-open sidebar when pressing back button

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -82,7 +82,6 @@ export default function Sidebar() {
     }
   }
 
-            </div>
   return (
     <>
       <div

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -45,7 +45,7 @@ interface GraphState {
   startTopic: (query: string) => Promise<void>;
   diveInto: (nodeId: string) => Promise<void>;
   goBack: () => void;
-  goToLevel: (depth: number) => Promise<void>;
+  goToLevel: (depth: number, openSidebar?: boolean) => Promise<void>;
   reset: () => Promise<void>;
   setSidebarOpen: (open: boolean) => void;
 }
@@ -786,12 +786,12 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         EMERGE_DURATION
       );
     } else {
-      get().goToLevel(newPath.length - 1);
+      get().goToLevel(newPath.length - 1, false);
     }
   },
 
   /* ---- Jump to a specific depth (e.g. breadcrumb click) ---- */
-  goToLevel: async (depth: number) => {
+  goToLevel: async (depth: number, openSidebar = true) => {
     const { path, userId, rootNodes } = get();
     if (!userId) return;
     if (depth < 0) {
@@ -864,7 +864,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         currentNodes: childResult.nodes,
         currentEdges: childResult.edges,
         outerContextNodes: [],
-        sidebarOpen: true,
+        sidebarOpen: openSidebar,
         diveAnimation: {
           phase: 'emerging',
           targetPos: null,


### PR DESCRIPTION
When goBack calls goToLevel, pass openSidebar=false so the sidebar stays closed. Clicking a node (diveInto) or a breadcrumb still opens it normally. Also fixes stray </div> syntax error in Sidebar.tsx.

https://claude.ai/code/session_01RCQJHrBYNqz2judGHQETNn