### PR TITLE
Add error logging and retry logic for summary/subtopics API failures

### DIFF
--- a/app/api/subtopics/route.ts
+++ b/app/api/subtopics/route.ts
@@ -221,9 +221,10 @@ Pick 12–15 subtopics most useful for learning "${topic}" and return the JSON.`
 
     return NextResponse.json({ subtopics, edges, edge_weights: edgeWeights, relevance, size });
   } catch (e: any) {
+    console.error('[api/subtopics] error:', e?.status ?? '', e?.message ?? e);
     return NextResponse.json(
-      { error: e?.message || 'Failed to curate subtopics' },
-      { status: 500 }
+      { error: e?.message || 'Failed to curate subtopics', code: e?.status ?? 'UNKNOWN' },
+      { status: e?.status === 429 ? 429 : 500 }
     );
   }
 }

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -90,6 +90,10 @@ export async function POST(req: Request) {
       resolvedTitle: resolvedTitle !== title ? resolvedTitle : undefined,
     });
   } catch (e: any) {
-    return NextResponse.json({ error: e.message ?? 'Failed' }, { status: 500 });
+    console.error('[api/summarize] error:', e?.status ?? '', e?.message ?? e);
+    return NextResponse.json(
+      { error: e.message ?? 'Failed', code: e?.status ?? 'UNKNOWN' },
+      { status: e?.status === 429 ? 429 : 500 }
+    );
   }
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -153,7 +153,8 @@ async function buildAncestorPath(
 /** Ask Haiku to curate subtopics from Wikipedia links. */
 async function curateSubtopics(
   topic: string,
-  exclude: string[]
+  exclude: string[],
+  retries = 2
 ): Promise<SubtopicsJson> {
   try {
     const res = await fetch('/api/subtopics', {
@@ -161,7 +162,15 @@ async function curateSubtopics(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ topic, exclude }),
     });
-    if (!res.ok) return { titles: [], edges: [] };
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      console.error(`[subtopics] ${res.status} for "${topic}":`, body);
+      if (retries > 0 && res.status >= 500) {
+        await new Promise((ok) => setTimeout(ok, 1000));
+        return curateSubtopics(topic, exclude, retries - 1);
+      }
+      return { titles: [], edges: [] };
+    }
     const data = await res.json();
     return {
       titles: Array.isArray(data.subtopics) ? data.subtopics : [],
@@ -170,7 +179,12 @@ async function curateSubtopics(
       relevance: Array.isArray(data.relevance) ? data.relevance : undefined,
       size: Array.isArray(data.size) ? data.size : undefined,
     };
-  } catch {
+  } catch (err) {
+    console.error(`[subtopics] network error for "${topic}":`, err);
+    if (retries > 0) {
+      await new Promise((ok) => setTimeout(ok, 1000));
+      return curateSubtopics(topic, exclude, retries - 1);
+    }
     return { titles: [], edges: [] };
   }
 }
@@ -696,12 +710,13 @@ export const useGraphStore = create<GraphState>((set, get) => ({
       // Load summary in parallel (doesn't block children)
       if (!node.summary) {
         set({ summaryStatus: 'loading' });
-        fetch('/api/summarize', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: node.wiki_title, nodeId: realId }),
-        })
-          .then(async (r) => {
+        const attemptSummary = async (retries = 2): Promise<void> => {
+          try {
+            const r = await fetch('/api/summarize', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ title: node.wiki_title, nodeId: realId }),
+            });
             if (r.ok) {
               const d = await r.json();
               node.summary = d.summary;
@@ -716,12 +731,24 @@ export const useGraphStore = create<GraphState>((set, get) => ({
                 set({ currentParent: { ...node }, summaryStatus: 'loaded' });
               }
             } else {
+              const body = await r.json().catch(() => ({}));
+              console.error(`[summarize] ${r.status} for "${node.wiki_title}":`, body);
+              if (retries > 0 && r.status >= 500) {
+                await new Promise((ok) => setTimeout(ok, 1000));
+                return attemptSummary(retries - 1);
+              }
               set({ summaryStatus: 'error' });
             }
-          })
-          .catch(() => {
+          } catch (err) {
+            console.error(`[summarize] network error for "${node.wiki_title}":`, err);
+            if (retries > 0) {
+              await new Promise((ok) => setTimeout(ok, 1000));
+              return attemptSummary(retries - 1);
+            }
             set({ summaryStatus: 'error' });
-          });
+          }
+        };
+        attemptSummary();
       } else {
         set({ summaryStatus: 'loaded' });
       }


### PR DESCRIPTION
Both /api/summarize and /api/subtopics silently swallowed errors, making
it impossible to diagnose failures like the "Couldn't load summary" state.
Now logs error details (status code, response body) and retries up to 2
times on 500+ / network errors before giving up.

https://claude.ai/code/session_017YT44xW6tdbstE5pn6gZYk