### PR TITLE
Fix mobile summary close button by preventing page scroll when sidebar is open

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -30,6 +30,16 @@ export default function Sidebar() {
     }
   }, [messages]);
 
+  // Prevent body scrolling when sidebar is open on mobile
+  useEffect(() => {
+    if (sidebarOpen && window.innerWidth < 768) {
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = '';
+      };
+    }
+  }, [sidebarOpen]);
+
   if (!sidebarOpen || !currentParent) return null;
 
   async function sendMessage() {


### PR DESCRIPTION
When the sidebar is open on mobile, prevent the background page from scrolling so users can easily access the close button without scrolling up.

https://claude.ai/code/session_019vdVL7V4V1neoQ7KE9RvjQ