### PR TITLE
Add /citizen civics flashcards, move timeline to /universe, minimal root hub

### DIFF
--- a/citizen/index.html
+++ b/citizen/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="Flashcards for the 128-question 2025 USCIS naturalization civics test. Tap to flip, shuffle to drill.">
-  <meta name="color-scheme" content="light">
-  <meta name="theme-color" content="#faf4ea">
+  <meta name="color-scheme" content="dark">
+  <meta name="theme-color" content="#121110">
   <title>Citizen — USCIS Civics Flashcards</title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="canonical" href="https://thenoonlight.com/citizen/">
@@ -16,13 +16,13 @@
   <meta name="twitter:card" content="summary">
   <style>
     :root{
-      color-scheme: light;
-      --bg:     #faf4ea;
-      --card:   #fffdf8;
-      --text:   #2a211a;
-      --muted:  #93857a;
-      --edge:   #eee2d0;
-      --accent: #c05621;
+      color-scheme: dark;
+      --bg:     #121110;
+      --card:   #1c1916;
+      --text:   #eae2d6;
+      --muted:  #8d8275;
+      --edge:   #2d2822;
+      --accent: #e0863f;
       --sans: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', 'Segoe UI', Arial, sans-serif;
       --mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Monaco, monospace;
     }


### PR DESCRIPTION
## What's in this PR

### New: `/citizen` — USCIS civics flashcards
- Flashcard study app for the 2025 USCIS naturalization civics test (128 questions), built as a self-contained static page (`citizen/index.html`) plus a data file (`citizen/citizen-questions.json`) — no build step, no dependencies.
- All 128 question/answer pairs were extracted from the official USCIS PDF *128 Civics Questions and Answers (2025 version)*, M-1778 (09/25), with the document's section groupings as categories (American Government / American History / Symbols and Holidays). The 2025 edition's content updates (Juneteenth, expanded Cabinet answers, reworded 14th Amendment question, etc.) are included.
- Tap/click to flip with a CSS 3D animation; sequential mode ("Card 14 / 128") and an endless shuffle mode (Spotify-style toggle, reshuffles on deck exhaustion, shows "Card N"); mode and position persist in `localStorage`.
- Dark warm theme: near-black background, soft off-white text, amber-orange accent; large mobile-first type; small accent line icons on a handful of answer sides where they reinforce memory (flag, document, landmark, scales).
- Keyboard support (arrows, space/enter), reduced-motion fallback, accessible toggle states.

### Site reorganization
- The Since the Big Bang timeline moved unchanged from the root to `/universe/` (canonical/OG URLs and favicon path updated).
- The root is now a minimal hub: three bare links — `/beta`, `/universe`, `/citizen` — on the dark background.
- The beta's "original timeline" fallback link now points to `/universe/` (source and built output).
- README documents the new one-directory-per-project layout.

## Testing
- Browser-tested in Chromium at iPhone viewport: flip, prev/next, shuffle toggle, deck-exhaustion reshuffle, refresh persistence, long-answer scrolling (Q48), hub navigation, and the moved `/universe` page all verified working with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01661Mew6vXjDdWHMc6iaeaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01661Mew6vXjDdWHMc6iaeaL)_