### PR TITLE
Citizen: tint the answer side + fix doubled star on iOS

### DIFF
--- a/citizen/index.html
+++ b/citizen/index.html
@@ -19,6 +19,8 @@
       color-scheme: dark;
       --bg:     #121110;
       --card:   #1c1916;
+      --card-back: #292013;
+      --edge-back: #4d3b20;
       --text:   #eae2d6;
       --muted:  #8d8275;
       --edge:   #2d2822;
@@ -57,16 +59,21 @@
     .stage{
       flex: 1 1 auto;
       min-height: 0;
-      display:flex; flex-direction:column; justify-content:center;
-      perspective: 1400px;
+      display:flex; flex-direction:column; justify-content:center; align-items:center;
       padding: 16px 0;
     }
-    .card{
+    .cardwrap{
       position: relative;
       width: 100%;
       height: 100%;
       max-height: 620px;
       min-height: 320px;
+      perspective: 1400px;
+    }
+    .card{
+      position: relative;
+      width: 100%;
+      height: 100%;
       cursor: pointer;
       outline: none;
       transform-style: preserve-3d;
@@ -87,9 +94,15 @@
       padding: 26px 24px;
       overflow: hidden;
     }
-    .face.back{ transform: rotateY(180deg); }
+    /* the answer side is tinted warmer so the two sides read differently at a glance */
+    .face.back{
+      transform: rotateY(180deg);
+      background: var(--card-back);
+      border-color: var(--edge-back);
+    }
 
-    /* star the current card, one button per face so it shows on both sides */
+    /* star the current card: a single button overlaid on the wrapper, outside the
+       3D flip — per-face copies leak through backface culling on iOS Safari */
     .star{
       appearance: none; border: none; background: none;
       position: absolute; top: 6px; right: 6px;
@@ -98,7 +111,7 @@
       border-radius: 50%;
       color: var(--muted);
       cursor: pointer;
-      z-index: 1;
+      z-index: 2;
     }
     .star svg{ width: 20px; height: 20px; display: block; }
     .star.on{ color: var(--accent); }
@@ -312,23 +325,22 @@
     <div class="loading" id="loading">loading&hellip;</div>
 
     <div class="stage" id="stage" hidden>
-      <div class="card" id="card" tabindex="0" role="button"
-           aria-label="Flashcard. Press Enter or tap to flip.">
-        <div class="face front">
-          <button class="star" aria-label="Star this card">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-          </button>
-          <div class="eyebrow" id="category"></div>
-          <div class="content"><p class="question" id="question"></p></div>
-          <div class="hint">tap to flip</div>
-        </div>
-        <div class="face back">
-          <button class="star" aria-label="Star this card">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-          </button>
-          <div class="eyebrow">Answer</div>
-          <div class="content" id="answerContent"></div>
-          <div class="hint">tap to flip back</div>
+      <div class="cardwrap">
+        <button class="star" id="starBtn" aria-label="Star this card">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        </button>
+        <div class="card" id="card" tabindex="0" role="button"
+             aria-label="Flashcard. Press Enter or tap to flip.">
+          <div class="face front">
+            <div class="eyebrow" id="category"></div>
+            <div class="content"><p class="question" id="question"></p></div>
+            <div class="hint">tap to flip</div>
+          </div>
+          <div class="face back">
+            <div class="eyebrow">Answer</div>
+            <div class="content" id="answerContent"></div>
+            <div class="hint">tap to flip back</div>
+          </div>
         </div>
       </div>
     </div>
@@ -508,10 +520,9 @@
 
     function updateStarUI(){
       const on = isStarred(currentCard().id);
-      document.querySelectorAll('.card .star').forEach(b => {
-        b.classList.toggle('on', on);
-        b.setAttribute('aria-label', on ? 'Unstar this card' : 'Star this card');
-      });
+      const b = el('starBtn');
+      b.classList.toggle('on', on);
+      b.setAttribute('aria-label', on ? 'Unstar this card' : 'Star this card');
       const any = state.starred.length > 0;
       const so = el('starOnly');
       so.setAttribute('aria-disabled', !any);
@@ -708,8 +719,7 @@
         render();
 
         el('card').addEventListener('click', flip);
-        document.querySelectorAll('.card .star').forEach(b =>
-          b.addEventListener('click', e => { e.stopPropagation(); toggleStar(currentIndex()); }));
+        el('starBtn').addEventListener('click', () => toggleStar(currentIndex()));
         el('prev').addEventListener('click', () => step(-1));
         el('next').addEventListener('click', () => step(1));
         el('shuffle').addEventListener('click', toggleMode);


### PR DESCRIPTION
## What's in this PR

Two fixes for the `/citizen` flashcard, both from real-device feedback.

### Answer side is now visibly different
The answer face gets a warmer brown surface (`#292013`) and border (`#4d3b20`) versus the question face's neutral dark, so you can tell at a glance which side you're looking at — no more relying on the small "Answer" eyebrow alone.

### Only one star
On iOS Safari the answer side showed **two** stars: the app had one star button per face, and the front face's button leaked through `backface-visibility` culling because its `z-index` promoted it to its own compositing layer. Replaced the per-face buttons with a **single** star button overlaid on a wrapper element outside the 3D-transformed card entirely — it can't be affected by backface rendering on any browser, and it stays put (and tappable without flipping the card) on both sides.

## Testing
Chromium at iPhone viewport: exactly one star button in the DOM, visible and toggleable on both faces without flipping the card; front/back computed backgrounds differ as intended; starring, starred-only review, list view, navigation, and persistence all still pass with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01661Mew6vXjDdWHMc6iaeaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01661Mew6vXjDdWHMc6iaeaL)_