### PR TITLE
Remove /beta link from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
 </head>
 <body>
   <nav>
-    <a href="/beta/">/beta</a>
     <a href="/universe/">/universe</a>
     <a href="/citizen/">/citizen</a>
   </nav>


### PR DESCRIPTION
Removes the `/beta` link from the landing page nav in `index.html`. The nav now shows just `/universe` and `/citizen`.

The `/beta/` build and `beta-src/` sources are untouched — the page is simply no longer linked from the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)